### PR TITLE
Fix drag-and-drop acceptance logic

### DIFF
--- a/concatenator_tab.py
+++ b/concatenator_tab.py
@@ -132,7 +132,8 @@ class ConcatenatorTab(QWidget):
             event.ignore()
 
     def dropEvent(self, event: QDropEvent):
-        had_file = False
+        """Handle drag and drop of files or text paths."""
+        added = False
         # Text drops
         if event.mimeData().hasText():
             lines = event.mimeData().text().strip().splitlines()
@@ -140,14 +141,16 @@ class ConcatenatorTab(QWidget):
                 path = convert_wsl_path(line.strip())
                 if path and os.path.isfile(path):
                     self.list_widget.add_file(path)
-                    had_file = True
-            event.acceptProposedAction()
-        # URL drops
-        if not had_file and event.mimeData().hasUrls():
+                    added = True
+        # URL drops (some platforms provide both text and url data)
+        if not added and event.mimeData().hasUrls():
             for url in event.mimeData().urls():
                 path = convert_wsl_path(url.toLocalFile())
                 if path and os.path.isfile(path):
                     self.list_widget.add_file(path)
+                    added = True
+
+        if added:
             event.acceptProposedAction()
         else:
             event.ignore()


### PR DESCRIPTION
## Summary
- fix drop event logic so dropping text or URL paths is accepted only when a file is added

## Testing
- `python -m py_compile *.py`
- `python -m py_compile concatenator_tab.py file_list_widget.py file_concatenator.py main_window.py settings_tab.py utils.py wsl_utilities.py code2clip.py`


------
https://chatgpt.com/codex/tasks/task_e_685d1e3315c88323928240dde06eea59