### PR TITLE
Add test for root paths with spaces

### DIFF
--- a/tests/test_file_concatenator.py
+++ b/tests/test_file_concatenator.py
@@ -70,5 +70,28 @@ class ConcatenateFilesTest(unittest.TestCase):
             self.assertNotIn('file1.txt/file1.txt', clip_text)
             self.assertNotIn('file2.txt/file2.txt', clip_text)
 
+    def test_spaces_in_root_path(self):
+        with tempfile.TemporaryDirectory(prefix="space path ") as tmpdir:
+            file1 = os.path.join(tmpdir, 'file1.txt')
+            subdir = os.path.join(tmpdir, 'sub dir')
+            os.makedirs(subdir)
+            file2 = os.path.join(subdir, 'file2.txt')
+            with open(file1, 'w') as f:
+                f.write('one')
+            with open(file2, 'w') as f:
+                f.write('two')
+
+            prefix = "<file path='$filepath'>"
+            suffix = "</file>"
+
+            self.concatenate_files([file1, file2], root_path=tmpdir,
+                                   prefix=prefix, suffix=suffix,
+                                   show_success_message=False)
+            clip_text = DummyQApplication._clipboard.text
+            self.assertIn("<file path='file1.txt'>", clip_text)
+            self.assertIn(os.path.join('sub dir', 'file2.txt'), clip_text)
+            self.assertNotIn('file1.txt/file1.txt', clip_text)
+            self.assertNotIn('file2.txt/file2.txt', clip_text)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure file concatenation handles spaces in the root path by adding a new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d24ea145883239fb6fd7477dfa442