### PR TITLE
Improve path error handling

### DIFF
--- a/tests/test_file_concatenator.py
+++ b/tests/test_file_concatenator.py
@@ -43,6 +43,8 @@ class ConcatenateFilesTest(unittest.TestCase):
         global concatenate_files
         from file_concatenator import concatenate_files  # noqa: E402
         self.concatenate_files = concatenate_files
+        qtwidgets.QMessageBox.warning.reset_mock()
+        DummyQApplication._clipboard.text = ""
 
     def tearDown(self):
         self.modules_patcher.stop()
@@ -69,6 +71,44 @@ class ConcatenateFilesTest(unittest.TestCase):
             self.assertIn(os.path.join('sub', 'file2.txt'), clip_text)
             self.assertNotIn('file1.txt/file1.txt', clip_text)
             self.assertNotIn('file2.txt/file2.txt', clip_text)
+
+    def test_relpath_error_falls_back_to_absolute(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file1 = os.path.join(tmpdir, 'file1.txt')
+            with open(file1, 'w') as f:
+                f.write('one')
+
+            prefix = "<file path='$filepath'>"
+            suffix = "</file>"
+
+            with patch('os.path.relpath', side_effect=ValueError):
+                self.concatenate_files([file1], root_path=tmpdir,
+                                       prefix=prefix, suffix=suffix,
+                                       show_success_message=False)
+
+            clip_text = DummyQApplication._clipboard.text
+            self.assertIn(file1, clip_text)
+            qtwidgets.QMessageBox.warning.assert_called_once()
+
+    def test_multiple_relpath_errors_warn_once(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file1 = os.path.join(tmpdir, 'file1.txt')
+            file2 = os.path.join(tmpdir, 'file2.txt')
+            with open(file1, 'w') as f:
+                f.write('one')
+            with open(file2, 'w') as f:
+                f.write('two')
+
+            prefix = "<file path='$filepath'>"
+            suffix = "</file>"
+
+            qtwidgets.QMessageBox.warning.reset_mock()
+            with patch('os.path.relpath', side_effect=ValueError):
+                self.concatenate_files([file1, file2], root_path=tmpdir,
+                                       prefix=prefix, suffix=suffix,
+                                       show_success_message=False)
+
+            self.assertEqual(qtwidgets.QMessageBox.warning.call_count, 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 
 def resource_path(rel_path: str) -> str:
     """
@@ -18,3 +19,23 @@ def get_app_version():
         return open(resource_path("code2clip_version.txt")).read().strip()
     except:
         return "Loading..."
+
+
+def safe_relpath(path: str, start: str | None) -> tuple[str, str | None]:
+    """Return a path relative to ``start`` if possible."""
+    if not start:
+        return os.path.basename(path), None
+    try:
+        return os.path.relpath(path, start), None
+    except ValueError:
+        msg = (
+            "Cannot calculate relative path because the file and root path are on "
+            "different drives or filesystems. Displaying the absolute path instead."
+        )
+        return path, msg
+    except Exception as e:
+        msg = (
+            f"Failed to calculate relative path:\n{e}\n"
+            "Displaying the absolute path instead."
+        )
+        return path, msg


### PR DESCRIPTION
## Summary
- add `safe_relpath` helper
- show meaningful message when relative path resolution fails
- use `safe_relpath` in file listing and concatenation logic
- test relpath failure handling
- show warnings only once when multiple paths fail

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d2490139c8323bb15b9a58e37a903