### PR TITLE
Increase test coverage for utils and helpers

### DIFF
--- a/tests/test_file_concatenator_extra.py
+++ b/tests/test_file_concatenator_extra.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from tests.test_file_concatenator import DummyQApplication, modules
+
+class EscapeSequenceTest(unittest.TestCase):
+    def setUp(self):
+        self.modules_patcher = patch.dict(sys.modules, modules)
+        self.modules_patcher.start()
+        from file_concatenator import concatenate_files
+        self.concatenate_files = concatenate_files
+        DummyQApplication._clipboard.text = ''
+
+    def tearDown(self):
+        self.modules_patcher.stop()
+
+    def test_escape_sequences(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'a.txt')
+            with open(path, 'w') as f:
+                f.write('data')
+            self.concatenate_files([path], prefix='start\n', suffix='end\t',
+                                   show_success_message=False,
+                                   interpret_escape_sequences=True)
+            text = DummyQApplication._clipboard.text
+            self.assertIn('start\n'.encode('utf-8').decode('unicode_escape'), text)
+            self.assertIn('end\t'.encode('utf-8').decode('unicode_escape'), text)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import tempfile
+from unittest import mock
+
+import unittest
+
+from utils import resource_path, get_app_version, safe_relpath
+
+class TestResourcePath(unittest.TestCase):
+    def test_not_frozen(self):
+        # When not frozen, resource_path should join with abspath('.')
+        rel = 'some/file.txt'
+        expected = os.path.join(os.path.abspath('.'), rel)
+        self.assertEqual(resource_path(rel), expected)
+
+    def test_frozen(self):
+        with mock.patch.object(sys, 'frozen', True, create=True), \
+             mock.patch.object(sys, '_MEIPASS', '/tmp/meipass', create=True):
+            self.assertEqual(resource_path('a'), os.path.join('/tmp/meipass', 'a'))
+
+class TestGetAppVersion(unittest.TestCase):
+    def test_existing_version_file(self):
+        with unittest.mock.patch('utils.resource_path', return_value='temp_version.txt'):
+            with open('temp_version.txt', 'w') as f:
+                f.write('1.2.3')
+            try:
+                self.assertEqual(get_app_version(), '1.2.3')
+            finally:
+                os.remove('temp_version.txt')
+
+    def test_missing_version_file(self):
+        with unittest.mock.patch('utils.resource_path', return_value='nonexistent.txt'):
+            self.assertEqual(get_app_version(), 'Loading...')
+
+class TestSafeRelpath(unittest.TestCase):
+    def test_success(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, 'file.txt')
+            with open(file_path, 'w'):
+                pass
+            rel, msg = safe_relpath(file_path, tmpdir)
+            self.assertEqual(rel, 'file.txt')
+            self.assertIsNone(msg)
+
+    def test_valueerror(self):
+        with mock.patch('os.path.relpath', side_effect=ValueError):
+            path, msg = safe_relpath('a', 'b')
+            self.assertEqual(path, 'a')
+            self.assertIn('different drives', msg)
+
+    def test_exception(self):
+        with mock.patch('os.path.relpath', side_effect=RuntimeError('boom')):
+            path, msg = safe_relpath('a', 'b')
+            self.assertEqual(path, 'a')
+            self.assertIn('boom', msg)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_wsl_utils.py
+++ b/tests/test_wsl_utils.py
@@ -1,0 +1,26 @@
+import os
+from unittest import mock
+import unittest
+
+import wsl_utilities
+
+class TestConvertWslPath(unittest.TestCase):
+    def test_non_windows(self):
+        with mock.patch('platform.system', return_value='Linux'):
+            self.assertEqual(wsl_utilities.convert_wsl_path('/tmp/file'), '/tmp/file')
+
+    def test_windows_conversion(self):
+        with mock.patch('platform.system', return_value='Windows'), \
+             mock.patch('wsl_utilities.get_default_wsl_distro', return_value='Ubuntu'), \
+             mock.patch('os.path.isfile', return_value=True):
+            result = wsl_utilities.convert_wsl_path('/home/user/file')
+            expected = '\\\\wsl.localhost\\Ubuntu\\home\\user\\file'
+            self.assertEqual(result, expected)
+
+    def test_windows_no_conversion(self):
+        with mock.patch('platform.system', return_value='Windows'), \
+             mock.patch('wsl_utilities.get_default_wsl_distro', return_value=None):
+            self.assertEqual(wsl_utilities.convert_wsl_path('/path'), '/path')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for utility helpers and WSL path conversion
- add unit test covering escape sequence handling in `concatenate_files`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db82d19508323825fb71dc2146fd0